### PR TITLE
Fix: jre-libbluray 依赖  libbluary的源代码 ,添加:PKG_DEPENDS_UNPACK += libbluary

### DIFF
--- a/packages/addons/addon-depends/jre-depends/jre-libbluray/package.mk
+++ b/packages/addons/addon-depends/jre-depends/jre-libbluray/package.mk
@@ -7,7 +7,7 @@ PKG_NAME="jre-libbluray"
 PKG_DEPENDS_TARGET+=" apache-ant:host"
 PKG_LONGDESC="libbluray jar for BD-J menus"
 PKG_URL=""
-PKG_DEPENDS_UNPACK+=" jdk-x86_64-zulu"
+PKG_DEPENDS_UNPACK+=" jdk-x86_64-zulu libbluray"
 PKG_PATCH_DIRS+=" $(get_pkg_directory libbluray)/patches"
 PKG_BUILD_FLAGS="-sysroot"
 


### PR DESCRIPTION
(cherry picked from commit 1207e8bb8b60e5fa7a0399bfe2aac63ced040547)

jre-libbluray 依赖  libbluary的源代码,直接unpack https://github.com/RuralHunter/CoreELEC/blob/5133b6cecba20266802f6930f61aaf13a2341497/packages/addons/addon-depends/jre-depends/jre-libbluray/package.mk#L16 会提示找不到 `libbluray-${PKG_VERSION}.tar.bz2`


修改为 PKG_DEPENDS_UNPACK+=" jdk-x86_64-zulu libbluray" 添加 libbluray 依赖 确保编译的时候libbluray的代码存在于sources目录下面